### PR TITLE
Store and get lists from database.

### DIFF
--- a/groceries/__init__.py
+++ b/groceries/__init__.py
@@ -1,4 +1,9 @@
 from . import classification
+from permissions import deta
+
+
+grocery_db = deta.Base("groceries")
+
 
 def handler(content: str, options: dict):
     if options.get("help", None):
@@ -9,5 +14,22 @@ def handler(content: str, options: dict):
     # Options
     setup = options.get("setup", None)
 
-    return classification.classify_grocery_list(content, setup=setup)
+    if options.get("add", None):
+        old_key = options["id"]
+        old_list = grocery_db.get(old_key)
+
+        if not old_list:
+            return f"No existing list was found with ID {options['id']}."
+
+        # Append old list to current list 
+        old_list = old_list["list"]
+        content += f"\n{old_list}"
+
+    # List
+    sorted_list = classification.classify_grocery_list(content, setup=setup)
+
+    # IDs
+    key = grocery_db.put({"list": content})["key"]
+    
+    return f"List ID: {key}\n\n{sorted_list}"
     


### PR DESCRIPTION
Allows appending. Because of the concatenation limitation, messages with more than 160 characters cannot be processed. So, store grocery lists in a separate Deta Base (within the same project) and assign each list a new unique ID once it's been registered. Add a new option `"add"` when when true, pulls the given option `"id"`, sticks the current and found lists together, processes them as one, and sends it back to the user. 

https://github.com/preritdas/personal-api/blob/4e968f845669ed3627976f2746ab20af0db9bd38/groceries/__init__.py#L17-L32

This means that a user *will* have to send multiple texts for only one list, but this seems to be the best way to handle long grocery lists for now.