### PR TITLE
Smart list appending in Grocieres app.

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -28,7 +28,7 @@ jobs:
         run: pip install -r requirements.txt
 
       - name: Install test dependencies
-        run: pip install pytest pytest-cov coverage-badge
+        run: pip install -r tests/requirements.txt
 
       - name: Inject keys and config
         run: |

--- a/app_groceries/__init__.py
+++ b/app_groceries/__init__.py
@@ -1,4 +1,8 @@
+"""Groceries app."""
+import datetime as dt
+
 import utils
+import config
 
 from . import classification
 from permissions import deta
@@ -15,17 +19,34 @@ APP_OPTIONS = {
 grocery_db = deta.Base("groceries")
 
 
+def latest_grocery_list(phone: str) -> dict:
+    """Finds the last grocery list belonging to `phone`. Returns an empty dictionary if there are no lists belonging to `phone`."""
+    db_res = grocery_db.fetch({"phone": phone}).items
+    
+    if not db_res: 
+        return {}
+
+    return max(
+        db_res, 
+        key = lambda item: dt.datetime.strptime(
+            item["time"], 
+            config.Groceries.FULL_DT_FORMAT
+        )
+    )
+    
+
 @utils.app_handler(APP_HELP, APP_OPTIONS)
 def handler(content: str, options: dict):
     # Options
     setup = options.get("setup", None)
 
-    if options.get("add", None):
-        old_key = options["id"]
-        old_list = grocery_db.get(old_key)
+    if (list_id := options.get("add", None)):
+        # Get the user's last list
+        old_list = latest_grocery_list(options["inbound_phone"]) if list_id == "last" \
+            else grocery_db.get(list_id)
 
         if not old_list:
-            return f"No existing list was found with ID {options['id']}."
+            return f"No existing list was found."
 
         # Append old list to current list 
         old_list = old_list["list"]
@@ -35,7 +56,13 @@ def handler(content: str, options: dict):
     sorted_list = classification.classify_grocery_list(content, setup=setup)
 
     # IDs
-    key = grocery_db.put({"list": content})["key"]
+    put_item = grocery_db.put(
+        {
+            "list": content,
+            "phone": options["inbound_phone"],
+            "time": dt.datetime.now().strftime(config.Groceries.FULL_DT_FORMAT)
+        }
+    )
     
-    return f"List ID: {key}\n\n{sorted_list}"
+    return f"List ID: {put_item['key']}\n\n{sorted_list}"
     

--- a/app_groceries/classification.py
+++ b/app_groceries/classification.py
@@ -8,7 +8,7 @@ from . import grocery_utils
 
 
 # Optional translation
-if config.Groceries.translation:
+if config.Groceries.TRANSLATION:
     import translators
     translate = lambda phrase: translators.google(phrase)
 else:

--- a/app_weather/__init__.py
+++ b/app_weather/__init__.py
@@ -8,7 +8,7 @@ from .data import kelvin_to_farenheit as farenheit
 
 APP_HELP = "Get weather data."
 APP_OPTIONS = {
-    "city": f"OPTIONAL, default is {config.Weather.default_city}",
+    "city": f"OPTIONAL, default is {config.Weather.DEFAULT_CITY}",
     "state": "OPTIONAL, U.S. state, city is usually sufficient",
     "country": "OPTIONAL, ISO code, city is usuaully sufficient"
 }
@@ -17,7 +17,7 @@ APP_OPTIONS = {
 @utils.app_handler(APP_HELP, APP_OPTIONS)
 def handler(content: str, options: dict) -> str:
     """Weather data."""
-    city = options.get("city", config.Weather.default_city)
+    city = options.get("city", config.Weather.DEFAULT_CITY)
     state = options.get("state", "")
     country = options.get("country", "")
 

--- a/config.py
+++ b/config.py
@@ -25,9 +25,11 @@ config.read(
 
 
 class Weather:
-    default_city = config["Weather"]["default_city"]
+    DEFAULT_CITY = config["Weather"]["default_city"]
 
 
 class Groceries:
-    translation = True if config["Groceries"]["translation"].lower().strip() == "true" \
+    TRANSLATION = True if config["Groceries"]["translation"].lower().strip() == "true" \
         else False
+
+    FULL_DT_FORMAT = "%Y-%m-%d %H-%M-%S"

--- a/tests/badge.svg
+++ b/tests/badge.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">91%</text>
-        <text x="80" y="14">91%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">93%</text>
+        <text x="80" y="14">93%</text>
     </g>
 </svg>

--- a/tests/badge.svg
+++ b/tests/badge.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">92%</text>
-        <text x="80" y="14">92%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">91%</text>
+        <text x="80" y="14">91%</text>
     </g>
 </svg>

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,3 @@
+pytest==7.1.3
+pytest-cov==4.0.0
+coverage-badge==1.1.0

--- a/tests/test_app_groceries.py
+++ b/tests/test_app_groceries.py
@@ -22,9 +22,8 @@ def test_handler():
     )
 
     assert "List ID" in res
-    assert "Apples" in res
-    assert "Bananas" in res
-    assert "Chicken in res"
+    assert all(item in res for item in test_items)
+    assert "Chicken" in res
 
 
 def test_help():

--- a/tests/test_app_groceries.py
+++ b/tests/test_app_groceries.py
@@ -4,7 +4,7 @@ import app_groceries
 def test_handler():
     res = app_groceries.handler(
         content = "Apples\nBananas",
-        options = {"setup": "whole foods"}
+        options = {"setup": "whole foods", "inbound_phone": "12223334455"}
     )
 
     assert "List ID" in res

--- a/tests/test_app_groceries.py
+++ b/tests/test_app_groceries.py
@@ -1,14 +1,30 @@
+import random
+
 import app_groceries
 
 
 def test_handler():
+    ITEMS = ["Apples", "Bananas", "Blueberries", "snacks", "pears", "limes", "lamb"]
+    test_items = random.sample(ITEMS, 2)  # get a few random items for testing
+
     res = app_groceries.handler(
-        content = "Apples\nBananas",
+        content = "\n".join(test_items),
         options = {"setup": "whole foods", "inbound_phone": "12223334455"}
     )
 
     assert "List ID" in res
     assert "Apples" in res
+
+    # Test adding items with last feature
+    res = app_groceries.handler(
+        content = "Chicken",
+        options = {"inbound_phone": "12223334455", "add": "last"}
+    )
+
+    assert "List ID" in res
+    assert "Apples" in res
+    assert "Bananas" in res
+    assert "Chicken in res"
 
 
 def test_help():

--- a/tests/test_app_groceries.py
+++ b/tests/test_app_groceries.py
@@ -13,7 +13,7 @@ def test_handler():
     )
 
     assert "List ID" in res
-    assert "Apples" in res
+    assert all(item in res for item in test_items)
 
     # Test adding items with last feature
     res = app_groceries.handler(
@@ -22,7 +22,6 @@ def test_handler():
     )
 
     assert "List ID" in res
-    assert all(item in res for item in test_items)
     assert "Chicken" in res
 
 


### PR DESCRIPTION
When adding items to an old list, instead of having to manually add two fields, `add` and `id`, now use use `add` and provide either the list ID as a value or `"last"`, which will query the database for that particular user's last stored grocery list. 

Previously...

```text
app: groceries
options: add = yes; id = 8asdc78asdc; setup = whole foods

new items
2 new item
```

Now...

```text
app: groceries
options: add = last; setup = whole foods

new items
2 new item
```

Querying the database...

https://github.com/preritdas/personal-api/blob/9ea1da07d8da0827c867f4e10515237792ebd2fe/app_groceries/__init__.py#L22-L35

Storing more than just the list items. Also storing user's phone number and string-formatted time of request.

https://github.com/preritdas/personal-api/blob/9ea1da07d8da0827c867f4e10515237792ebd2fe/app_groceries/__init__.py#L58-L65