### PR TITLE
Randomized fixtures for test concurrency.

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,31 +2,40 @@
 import pytest
 
 import datetime as dt
+import string
+import random
 
 import usage  # fixture for temporary logs for report
 import permissions  # fixtures for temporary users
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def default_inbound() -> dict[str, str]:
+    random_inbound = "".join(
+        [str(random.choice([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])) for _ in range(10)]
+    )
+
     return {
-        "msisdn": "12223334455",
+        "msisdn": random_inbound,
         "text": "app: apps"
     }
 
 
 @pytest.fixture
-def default_options() -> dict[str, str]:
-    return {"inbound_phone": "12223334455"}
+def default_options(default_inbound) -> dict[str, str]:
+    return {"inbound_phone": default_inbound["msisdn"]}
 
 
-@pytest.fixture
-def user_git_pytest() -> dict[str, str]:
-    """Temporary user with maximum permissions."""
+@pytest.fixture(scope="session")
+def user_git_pytest(default_inbound) -> dict[str, str]:
+    """Temporary random user with maximum permissions."""
+    first_name = "".join(random.sample(string.ascii_lowercase, 5)).title()
+    last_name = "".join(random.sample(string.ascii_lowercase, 5)).title()
+
     user_attrs = {
-        "Name": "Git Pytest",
+        "Name": f"{first_name} {last_name}",
         "Permissions": "all",
-        "Phone": "12223334455"
+        "Phone": default_inbound["msisdn"]
     }
 
     key = permissions.permissions_db.put(user_attrs)["key"]
@@ -34,22 +43,29 @@ def user_git_pytest() -> dict[str, str]:
     permissions.permissions_db.delete(key)
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def users_dup_namephone() -> list[dict[str, str]]:
     """
     Temporary users with the same name and phone number to test
     handling duplicate entries.
     """
+    first_name = "".join(random.sample(string.ascii_lowercase, 5)).title()
+    last_name = "".join(random.sample(string.ascii_lowercase, 5)).title()
+
+    phone_number = "".join(
+        [str(random.choice([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])) for _ in range(10)]
+    )
+
     users = [
         {
-            "Name": "Dup Namephone",
+            "Name": " ".join([first_name, last_name]),
             "Permissions": "groceries",
-            "Phone": "10101010101"
+            "Phone": phone_number
         },
         {
-            "Name": "Dup Namephone",
+            "Name": " ".join([first_name, last_name]),
             "Permissions": "apps",
-            "Phone": "10101010101"
+            "Phone": phone_number
         },
     ]
 

--- a/tests/test_app_apps.py
+++ b/tests/test_app_apps.py
@@ -1,7 +1,7 @@
 import app_apps
 
 # Pytest fixtures
-from . import default_options
+from . import default_options, default_inbound
 
 
 def test_handler(default_options):

--- a/tests/test_app_billsplit.py
+++ b/tests/test_app_billsplit.py
@@ -5,12 +5,12 @@ import app_billsplit
 from app_billsplit.actions import billsplit_db
 
 # Fixtures
-from . import default_options
+from . import default_options, default_inbound
 
 
 @pytest.fixture
-def temporary_session():
-    new_session = billsplit_db.Session.new("12223334455", 100, 10)
+def temporary_session(default_inbound):
+    new_session = billsplit_db.Session.new(default_inbound["msisdn"], 100, 10)
     yield new_session.phrase
     billsplit_db.db.delete(new_session.key)
 

--- a/tests/test_app_groceries.py
+++ b/tests/test_app_groceries.py
@@ -4,7 +4,7 @@ import app_groceries
 from app_groceries import grocery_utils
 
 # Fixtures
-from . import default_options
+from . import default_options, default_inbound
 
 
 def test_handler():

--- a/tests/test_app_invite.py
+++ b/tests/test_app_invite.py
@@ -8,7 +8,7 @@ import app_invite
 import keys
 
 # Fixtures
-from . import default_options
+from . import default_options, default_inbound
 
 
 def test_handler():

--- a/tests/test_app_permissions.py
+++ b/tests/test_app_permissions.py
@@ -7,7 +7,7 @@ import string
 import app_permissions
 
 # Fixtures
-from . import user_git_pytest, users_dup_namephone, default_options
+from . import user_git_pytest, users_dup_namephone, default_options, default_inbound
 
 
 def test_handler():
@@ -171,8 +171,8 @@ def test_delete_none_found():
 def test_query_error(users_dup_namephone):
     # By name
     with pytest.raises(app_permissions.query.QueryError):
-        app_permissions.query.query(name="dup namephone")
+        app_permissions.query.query(name=users_dup_namephone[0]["Name"])
 
     # By phone
     with pytest.raises(app_permissions.query.QueryError):
-        app_permissions.query.query(phone="10101010101")
+        app_permissions.query.query(phone=users_dup_namephone[0]["Phone"])

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -1,27 +1,26 @@
 """
 Check permissions. 
 
-12223334455 is a custom testing number used in the permissions
-database. It has permissions to use _all_ apps. 
-
-00000000000 is a custom testing number
-in the permissions database. It has permissions to use _only_ the groceries app.
+Using session scoped fixtures, defined in tests/__init__.py, for the users formerly
+Git Pytest and Dup Namephone. Their names and phone numbers are now randomized so tests
+can be run concurrently without causing errors with duplicate values in the database
+causing un-tested-for results.
 """
 import permissions
 
 # Fixtures
-from . import user_git_pytest, users_dup_namephone
+from . import user_git_pytest, users_dup_namephone, default_inbound
 
 
 def test_check_permissions(user_git_pytest):
     assert permissions.check_permissions(
-        "12223334455", "wordhunt"
+        user_git_pytest["Phone"], "wordhunt"
     )
 
 
 def test_custom_permissions(users_dup_namephone):
     assert permissions.check_permissions(
-        "10101010101", "groceries"
+        users_dup_namephone[0]["Phone"], "groceries"
     )
 
 

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -6,7 +6,7 @@ import random
 import usage
 
 # Fixtures
-from . import temp_usage_logs, user_git_pytest
+from . import temp_usage_logs, user_git_pytest, default_inbound
 
 
 def test_log_use():
@@ -35,7 +35,7 @@ def test_log_use():
 
 
 def test_phone_to_name(user_git_pytest):
-    assert usage._phone_to_name(user_git_pytest["Phone"]) == "Git Pytest"
+    assert usage._phone_to_name(user_git_pytest["Phone"]) == user_git_pytest["Name"]
     assert usage._phone_to_name("11234567890") == "11234567890"
 
 


### PR DESCRIPTION
Use session-scoped fixtures, defined in `tests/__init__.py`, for the users formerly Git Pytest and Dup Namephone. Their names and phone numbers are now randomized so tests can be run concurrently without causing errors with duplicate values in the database causing un-tested-for results.