### PR TITLE
Separate inbound handling to test the main handler.

### DIFF
--- a/inbound.py
+++ b/inbound.py
@@ -29,14 +29,14 @@ def main_handler(inbound_sms_content: dict) -> dict[str, tuple | str]:
 
     # Valid assertion
     if not parsing.assert_valid(inbound_sms_content):
-        text_response = "Your message was invalid and unrecognized.",
+        text_response = "Your message was invalid and unrecognized."
         return {"response": text_response, "http": ("", 204)}
 
     # App availablity
     requested_app, app_name = parsing.requested_app(inbound_sms_content)
 
     if not requested_app:
-        text_response = f"That app does not exist.",
+        text_response = f"That app does not exist."
         texts.send_message(text_response, sender)
         return {"response": text_response, "http": ("", 204)}
 

--- a/inbound.py
+++ b/inbound.py
@@ -1,0 +1,70 @@
+"""
+Process and handle inbound requests. This is where the `main_handler` is defined,
+called by the Flask route and given inbound information.
+"""
+import parsing
+import permissions
+import texts
+import usage
+
+
+def main_handler(inbound_sms_content: dict) -> tuple[str, int]:
+    """
+    Handle all inbound messages.
+    
+    Keep this as simple as possible, with plenty of outsourcing.
+    """
+    sender: str = inbound_sms_content["msisdn"]
+
+    # No concat assertion
+    if parsing.is_concat(inbound_sms_content):
+        texts.send_message(
+            "Your message was too long. It was split by your carrier.",
+            sender
+        )
+        return "", 204
+
+    # Valid assertion
+    if not parsing.assert_valid(inbound_sms_content):
+        texts.send_message(
+            "Your message was invalid and unrecognized.",
+            sender
+        )
+        return "", 204
+
+    # App availablity
+    requested_app, app_name = parsing.requested_app(inbound_sms_content)
+
+    if not requested_app:
+        texts.send_message(
+            f"That app does not exist.",
+            sender
+        )
+        return "", 204
+
+    # App permissions
+    if not permissions.check_permissions(sender, app_name):
+        texts.send_message(
+            f"It seems you don't have permission to use app '{app_name}'.",
+            sender
+        )
+        return "", 204
+
+    # Run the app
+    content, options = parsing.app_content_options(inbound_sms_content)
+    options["inbound_phone"] = sender
+
+    try:
+        response = requested_app(content, options)
+    except Exception as e:
+        response = f"Unfortunately, that failed. '{str(e)}'"
+
+    texts.send_message(response, sender)
+    usage.log_use(
+        phone_number = sender,
+        app_name = app_name,
+        content = content,
+        options = options
+    ) 
+
+    return "", 204

--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 """
-Create the main Flask application and define the handlers to route inbound requests
-to the correct app. Use threading to instantly return a response at the inbound-sms
+Create the main Flask application with routes. Use the `inbound` module main handler. 
+Use threading to instantly return a response at the inbound-sms
 endpoint.
 """
 # External
@@ -10,75 +10,10 @@ from flask import Flask, request
 import threading
 
 # Project
-import parsing
-import permissions
-import texts
-import usage
+import inbound
 
 
 app = Flask(__name__)
-
-
-def main_handler(inbound_sms_content: dict) -> tuple[str, int]:
-    """
-    Handle all inbound messages.
-    
-    Keep this as simple as possible, with plenty of outsourcing.
-    """
-    sender: str = inbound_sms_content["msisdn"]
-
-    # No concat assertion
-    if parsing.is_concat(inbound_sms_content):
-        texts.send_message(
-            "Your message was too long. It was split by your carrier.",
-            sender
-        )
-        return "", 204
-
-    # Valid assertion
-    if not parsing.assert_valid(inbound_sms_content):
-        texts.send_message(
-            "Your message was invalid and unrecognized.",
-            sender
-        )
-        return "", 204
-
-    # App availablity
-    requested_app, app_name = parsing.requested_app(inbound_sms_content)
-
-    if not requested_app:
-        texts.send_message(
-            f"That app does not exist.",
-            sender
-        )
-        return "", 204
-
-    # App permissions
-    if not permissions.check_permissions(sender, app_name):
-        texts.send_message(
-            f"It seems you don't have permission to use app '{app_name}'.",
-            sender
-        )
-        return "", 204
-
-    # Run the app
-    content, options = parsing.app_content_options(inbound_sms_content)
-    options["inbound_phone"] = sender
-
-    try:
-        response = requested_app(content, options)
-    except Exception as e:
-        response = f"Unfortunately, that failed. '{str(e)}'"
-
-    texts.send_message(response, sender)
-    usage.log_use(
-        phone_number = sender,
-        app_name = app_name,
-        content = content,
-        options = options
-    ) 
-
-    return "", 204
 
 
 @app.route("/inbound-sms", methods=["POST"])
@@ -90,7 +25,7 @@ def main_handler_wrapper():
         return "Not JSON format.", 400
 
     process_inbound = threading.Thread(
-        target = main_handler,
+        target = inbound.main_handler,
         kwargs = {
             "inbound_sms_content": inbound_sms_content
         }

--- a/tests/badge.svg
+++ b/tests/badge.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">99%</text>
-        <text x="80" y="14">99%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">97%</text>
+        <text x="80" y="14">97%</text>
     </g>
 </svg>

--- a/tests/badge.svg
+++ b/tests/badge.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">97%</text>
-        <text x="80" y="14">97%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">99%</text>
+        <text x="80" y="14">99%</text>
     </g>
 </svg>

--- a/tests/test_main_handler.py
+++ b/tests/test_main_handler.py
@@ -2,15 +2,35 @@
 import inbound
 
 
-def test_sandbox(mocker):
+def test_success(mocker, default_inbound):
     mocker.patch("inbound.texts.config.General.SANDBOX_MODE", True)
+    mocker.patch("inbound.usage.config.General.SANDBOX_MODE", True)
 
-    content, status_code = inbound.main_handler(
+    res = inbound.main_handler(
         {
-            "msisdn": "14259023246",
-            "text": "app: apps"
+            **default_inbound,
         }
     )
 
-    assert not content
-    assert 200 <= status_code < 300
+    assert res["response"]
+    assert not res["http"][0]
+    assert 200 <= res["http"][1] < 300
+
+
+def test_message_concat(mocker, default_inbound):
+    """If the message is too long."""
+    mocker.patch("inbound.texts.config.General.SANDBOX_MODE", True)
+    mocker.patch("inbound.usage.config.General.SANDBOX_MODE", True)
+
+    res = inbound.main_handler(
+        {
+            **default_inbound,
+            "text": "test message that is too long and is split by the carrier",
+            "concat": "true",
+            "concat-part": "1"
+        }
+    )
+
+    assert "Your message was too long" in res["response"]
+    assert not res["http"][0]
+    assert 200 <= res["http"][1] < 300

--- a/tests/test_main_handler.py
+++ b/tests/test_main_handler.py
@@ -2,7 +2,7 @@
 import inbound
 
 
-def test_success(mocker, default_inbound):
+def test_no_permissions(mocker, default_inbound):
     mocker.patch("inbound.texts.config.General.SANDBOX_MODE", True)
     mocker.patch("inbound.usage.config.General.SANDBOX_MODE", True)
 
@@ -12,7 +12,7 @@ def test_success(mocker, default_inbound):
         }
     )
 
-    assert res["response"]
+    assert "you don't have permission" in res["response"]
     assert not res["http"][0]
     assert 200 <= res["http"][1] < 300
 
@@ -32,5 +32,71 @@ def test_message_concat(mocker, default_inbound):
     )
 
     assert "Your message was too long" in res["response"]
+    assert not res["http"][0]
+    assert 200 <= res["http"][1] < 300
+
+
+def test_invalid_inbound(mocker, default_inbound):
+    mocker.patch("inbound.texts.config.General.SANDBOX_MODE", True)
+    mocker.patch("inbound.usage.config.General.SANDBOX_MODE", True)
+
+    res = inbound.main_handler(
+        {
+            **default_inbound,
+            "text": "hello",
+        }
+    )
+
+    assert "invalid" in res["response"]
+    assert not res["http"][0]
+    assert 200 <= res["http"][1] < 300
+
+
+def test_invalid_app(mocker, default_inbound):
+    mocker.patch("inbound.texts.config.General.SANDBOX_MODE", True)
+    mocker.patch("inbound.usage.config.General.SANDBOX_MODE", True)
+
+    res = inbound.main_handler(
+        {
+            **default_inbound,
+            "text": "app: askjdcasldjc",
+        }
+    )
+
+    assert "app does not exist" in res["response"]
+    assert not res["http"][0]
+    assert 200 <= res["http"][1] < 300
+
+
+def test_run_app(mocker, user_git_pytest):
+    mocker.patch("inbound.texts.config.General.SANDBOX_MODE", True)
+    mocker.patch("inbound.usage.config.General.SANDBOX_MODE", True)
+
+    res = inbound.main_handler(
+        {
+            "msisdn": user_git_pytest["Phone"],
+            "text": "app: apps",
+        }
+    )
+
+    assert "available" in res["response"]
+    assert not res["http"][0]
+    assert 200 <= res["http"][1] < 300
+
+
+def test_app_error_handling(mocker, user_git_pytest):
+    mocker.patch("inbound.texts.config.General.SANDBOX_MODE", True)
+    mocker.patch("inbound.usage.config.General.SANDBOX_MODE", True)
+
+    res = inbound.main_handler(
+        {
+            "msisdn": user_git_pytest["Phone"],
+            "text": "app: wordhunt\n" \
+                "options: width = notnumber; height = notnumber\n" \
+                "hagsyausidmsnajs"
+        }
+    )
+
+    assert "Unfortunately" in res["response"]
     assert not res["http"][0]
     assert 200 <= res["http"][1] < 300

--- a/tests/test_main_handler.py
+++ b/tests/test_main_handler.py
@@ -1,0 +1,16 @@
+"""Testing if texts can be sandboxed with the Flask client."""
+import inbound
+
+
+def test_sandbox(mocker):
+    mocker.patch("inbound.texts.config.General.SANDBOX_MODE", True)
+
+    content, status_code = inbound.main_handler(
+        {
+            "msisdn": "14259023246",
+            "text": "app: apps"
+        }
+    )
+
+    assert not content
+    assert 200 <= status_code < 300

--- a/tests/test_main_handler.py
+++ b/tests/test_main_handler.py
@@ -9,6 +9,7 @@ def test_no_permissions(mocker, default_inbound):
     res = inbound.main_handler(
         {
             **default_inbound,
+            "msisdn": "192837261629"  # 11 digits as this would never be in the database
         }
     )
 

--- a/usage.py
+++ b/usage.py
@@ -4,9 +4,12 @@ import deta
 
 # Internal
 import datetime as dt
+import string
+import random
 
 # Project
 import keys
+import config
 
 
 deta = deta.Deta(keys.Deta.PROJECT_KEY)
@@ -52,6 +55,10 @@ def log_use(
         "Options": options,
         "Time": time
     }
+
+    # If in sandbox, return a fake key and don't post to database
+    if config.General.SANDBOX_MODE:
+        return "".join([random.choice(string.ascii_lowercase) for _ in range(12)])
 
     res: dict = usage_db.put(payload)
     return res["key"]


### PR DESCRIPTION
## Main Handler Independence and Tests

This was needed for quite a while. Originally, the `Flask` route itself handled the inbound messages. Then, there was a separate function, `main_handler`, that accepted `inbound_sms_content: dict` and handled the messages accordingly. This was untested, so problems in parsing and inbound handling would not be detected by the test suite until production.

Now, the main handler lives in a new `inbound.py` module, called by `main.main_handler_wrapper` which _is_ the `Flask` app route `/inbound-sms`. That way, the `inbound.main_handler` can be processed and tested before deployment.

The structure of the main handler was slightly altered too, so the user text response is returned. This is because the `main.main_handler_wrapper` uses a `threading.Thread` to process inbound and doesn't wait for or use a return value from `inbound.main_handler`. The return value can then be used in testing to verify that the `inbound.main_handler` is performing as it should.

https://github.com/preritdas/personal-api/blob/483b467573bd1fd0fb6d280f797a7dd7c2c976bd/inbound.py#L1-L21

## Misc

- Add a sandbox mode to the `usage` module so that when `usage.log_use` is called, an entry isn't actually created in the usage database. This is useful when testing.