### PR TITLE
Migrate from Nexmo to Twilio

### DIFF
--- a/inbound.py
+++ b/inbound.py
@@ -8,7 +8,7 @@ import texts
 import usage
 
 
-def main_handler(inbound_sms_content: dict) -> dict[str, tuple | str]:
+def main_handler(inbound_sms_content: parsing.InboundMessage) -> dict[str, tuple | str]:
     """
     Handle all inbound messages. Returns a dictionary in the following format.
 
@@ -19,7 +19,7 @@ def main_handler(inbound_sms_content: dict) -> dict[str, tuple | str]:
     
     Keep this as simple as possible, with plenty of outsourcing.
     """
-    sender: str = inbound_sms_content["msisdn"]
+    sender: str = inbound_sms_content.phone_number
 
     # No concat assertion
     if parsing.is_concat(inbound_sms_content):

--- a/inbound.py
+++ b/inbound.py
@@ -21,11 +21,12 @@ def main_handler(inbound_sms_content: parsing.InboundMessage) -> dict[str, tuple
     """
     sender: str = inbound_sms_content.phone_number
 
-    # No concat assertion
-    if parsing.is_concat(inbound_sms_content):
-        text_response = "Your message was too long. It was split by your carrier."
-        texts.send_message(text_response, sender)
-        return {"response": text_response, "http": ("", 204)}
+    # Removed after Twilio migration. Add back if Twilio has concat issues like Nexmo.
+    # # No concat assertion
+    # if parsing.is_concat(inbound_sms_content):
+    #     text_response = "Your message was too long. It was split by your carrier."
+    #     texts.send_message(text_response, sender)
+    #     return {"response": text_response, "http": ("", 204)}
 
     # Valid assertion
     if not parsing.assert_valid(inbound_sms_content):

--- a/keys.py
+++ b/keys.py
@@ -41,14 +41,13 @@ def environment_or_internal(env: str, provider: str) -> str:
         return keys[provider]["api_key"]  # raise KeyError if not found
 
 
-class Nexmo:
+class Twilio:
     """Sending text messages."""
-    _nexmo_keys = keys["Nexmo"]
+    _twilio_keys = keys["Twilio"]
 
-    API_KEY = _nexmo_keys["api_key"]
-    API_SECRET = _nexmo_keys["api_secret"]
-    SENDER = _nexmo_keys["sender"]
-    MY_NUMBER = _nexmo_keys["receiver"]
+    ACCOUNT_SID = _twilio_keys["account_sid"]
+    AUTH_TOKEN = _twilio_keys["auth_token"]
+    SENDER = _twilio_keys["sender"]
 
 
 class Deta:

--- a/keys.py
+++ b/keys.py
@@ -2,11 +2,11 @@
 Read keys.ini and parse. Supply keys.ini in the following format.
 
 
-[Nexmo]
-api_key = 
-api_secret = 
+[Twilio]
+account_sid = 
+auth_token = 
 sender = 
-receiver = 
+my_number = 
 
 
 [Deta]
@@ -48,6 +48,7 @@ class Twilio:
     ACCOUNT_SID = _twilio_keys["account_sid"]
     AUTH_TOKEN = _twilio_keys["auth_token"]
     SENDER = _twilio_keys["sender"]
+    MY_NUMBER = _twilio_keys["my_number"]
 
 
 class Deta:

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ Use threading to instantly return a response at the inbound-sms
 endpoint.
 """
 # External
-from fastapi import FastAPI
+from fastapi import FastAPI, Form
 
 # Local
 import threading
@@ -37,11 +37,13 @@ def route_to_handler(inbound_sms_content: dict) -> None:
 
 
 @app.post("/inbound-sms", status_code=204)
-def main_handler_wrapper(inbound: parsing.NexmoInbound):
+def main_handler_wrapper(From: str = Form(...), Body: str = Form(...)):
     """Handle the inbound, routing it to the handler."""
-    print("\n", inbound, sep="")
-    print(inbound.dict())
-    route_to_handler(inbound.dict())
+    # Validate the data
+    inbound_model = parsing.InboundMessage(phone_number=From, body=Body)
+
+    # Process the request
+    route_to_handler(inbound_model.dict())
 
     return ""
 

--- a/parsing.py
+++ b/parsing.py
@@ -10,17 +10,12 @@ import errors
 import apps
 
 
-class NexmoInbound(pydantic.BaseModel):
+class InboundMessage(pydantic.BaseModel):
     """
-    Inbound structure from Nexmo.
+    Inbound structure to be used .
     """
-    msisdn: str
-    text: str
-    concat: str | bool = False
-
-    def __post_init__(self):
-        """Apply some data modifications."""
-        self.concat = bool(self.concat)
+    phone_number: str
+    body: str
 
 
 def assert_valid(inbound: dict) -> bool:
@@ -34,10 +29,10 @@ def assert_valid(inbound: dict) -> bool:
     return True
 
 
-def is_concat(inbound: dict) -> bool:
-    """Determines if an inbound sms is part of a concatenated series of messages."""
-    assert isinstance(inbound, dict)
-    return bool(inbound["concat"])
+# def is_concat(inbound: dict) -> bool:
+#     """Determines if an inbound sms is part of a concatenated series of messages."""
+#     assert isinstance(inbound, dict)
+#     return bool(inbound["concat"])
 
 
 def requested_app(inbound: dict) -> tuple[Callable | None, str]:

--- a/parsing.py
+++ b/parsing.py
@@ -18,9 +18,9 @@ class InboundMessage(pydantic.BaseModel):
     body: str
 
 
-def assert_valid(inbound: dict) -> bool:
+def assert_valid(inbound: InboundMessage) -> bool:
     """Check that an inbound sms conforms to necessary structure."""
-    content: str = inbound["text"]
+    content: str = inbound.body
     first_line = (all_lines := content.splitlines())[0].lower()
 
     if not "app:" in first_line:
@@ -35,10 +35,10 @@ def assert_valid(inbound: dict) -> bool:
 #     return bool(inbound["concat"])
 
 
-def requested_app(inbound: dict) -> tuple[Callable | None, str]:
+def requested_app(inbound: InboundMessage) -> tuple[Callable | None, str]:
     """Returns the handler function of an app and its name, or None
     if the app doesn't exist."""
-    content: str = inbound["text"]
+    content: str = inbound.body
     first_line = (all_lines := content.splitlines())[0].lower()
 
     if not "app:" in first_line:

--- a/parsing.py
+++ b/parsing.py
@@ -69,9 +69,9 @@ def _parse_options(options: str) -> dict[str, str]:
     return return_options
 
 
-def app_content_options(inbound: dict) -> tuple[str, dict]:
+def app_content_options(inbound: InboundMessage) -> tuple[str, dict]:
     """Returns app input content."""
-    raw_content: str = inbound["text"]
+    raw_content: str = inbound.body
     lines = raw_content.splitlines()
 
     content = True

--- a/permissions.py
+++ b/permissions.py
@@ -23,7 +23,7 @@ def db_init() -> str:
     db_res: dict = permissions_db.put(
         {
             "Name": "Prerit Das",
-            "Phone": keys.Nexmo.MY_NUMBER,
+            "Phone": keys.Twilio.MY_NUMBER,
             "Permissions": "all"
         }
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ deta==1.1.0  # permissions
 # Server
 gunicorn==20.1.0
 uvicorn==0.20.0
+python-multipart==0.0.6
 
 # Groceries
 inflect==6.0.2  # word singularization and pluralization

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 fastapi==0.91.0  # API
-nexmo==2.5.2  # respond with texts
+twilio==8.0.0  # respond with texts
 deta==1.1.0  # permissions
 
 # Server

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,15 +16,14 @@ def default_inbound() -> dict[str, str]:
     )
 
     return {
-        "msisdn": random_inbound,
-        "text": "app: apps",
-        "concat": None
+        "phone_number": random_inbound,
+        "body": "app: apps",
     }
 
 
 @pytest.fixture
 def default_options(default_inbound) -> dict[str, str]:
-    return {"inbound_phone": default_inbound["msisdn"]}
+    return {"inbound_phone": default_inbound["phone_number"]}
 
 
 @pytest.fixture(scope="session")
@@ -62,7 +61,7 @@ def user_git_pytest(default_inbound) -> dict[str, str]:
     user_attrs = {
         "Name": f"{first_name} {last_name}",
         "Permissions": "all",
-        "Phone": default_inbound["msisdn"]
+        "Phone": default_inbound["phone_number"]
     }
 
     key = permissions.permissions_db.put(user_attrs)["key"]

--- a/tests/test_app_billsplit.py
+++ b/tests/test_app_billsplit.py
@@ -7,7 +7,7 @@ from apps.billsplit.actions import billsplit_db
 
 @pytest.fixture
 def temporary_session(default_inbound):
-    new_session = billsplit_db.Session.new(default_inbound["msisdn"], 100, 10)
+    new_session = billsplit_db.Session.new(default_inbound["phone_number"], 100, 10)
     yield new_session.phrase
     billsplit_db.db.delete(new_session.key)
 

--- a/tests/test_app_invite.py
+++ b/tests/test_app_invite.py
@@ -2,7 +2,10 @@
 Test the invite app. Make sure to pass "preview" to all the handler options 
 (except help) to prevent actual text messages from being sent.
 """
+import pytest
+
 from twilio.rest import Client  # mock an invalid client
+from twilio.base.exceptions import TwilioRestException
 
 from apps import invite
 import keys
@@ -46,9 +49,10 @@ def test_inviting(mocker, default_options):
 
 def test_failed_delivery(mocker, default_options):
     """Mock a bad API key."""
-    mocker.patch("texts.twilio_client", Client(keys.Twilio.ACCOUNT_SID, secret="invalid"))
-    res = invite.handler("14259023246", default_options)
-    assert "There was an error" in res
+    mocker.patch("texts.twilio_client", Client(keys.Twilio.ACCOUNT_SID, "invalid"))
+
+    with pytest.raises(TwilioRestException):
+        invite.handler("14259023246", default_options)
 
 
 def test_help():

--- a/tests/test_app_invite.py
+++ b/tests/test_app_invite.py
@@ -2,7 +2,7 @@
 Test the invite app. Make sure to pass "preview" to all the handler options 
 (except help) to prevent actual text messages from being sent.
 """
-import nexmo  # mock an invalid client
+from twilio.rest import Client  # mock an invalid client
 
 from apps import invite
 import keys
@@ -46,7 +46,7 @@ def test_inviting(mocker, default_options):
 
 def test_failed_delivery(mocker, default_options):
     """Mock a bad API key."""
-    mocker.patch("texts.sms", nexmo.Sms(key=keys.Nexmo.API_KEY, secret="invalid"))
+    mocker.patch("texts.twilio_client", Client(keys.Twilio.ACCOUNT_SID, secret="invalid"))
     res = invite.handler("14259023246", default_options)
     assert "There was an error" in res
 

--- a/tests/test_main_handler.py
+++ b/tests/test_main_handler.py
@@ -1,52 +1,54 @@
 """Testing if texts can be sandboxed with the FastAPI client."""
 import inbound
+from parsing import InboundMessage
 
 
 def test_no_permissions(mocker, default_inbound):
     mocker.patch("inbound.texts.config.General.SANDBOX_MODE", True)
     mocker.patch("inbound.usage.config.General.SANDBOX_MODE", True)
 
-    res = inbound.main_handler(
-        {
-            **default_inbound,
-            "msisdn": "192837261629"  # 11 digits as this would never be in the database
-        }
-    )
+    inbound_payload = {
+        **default_inbound,
+        "phone_number": "192837261629"  # 11 digits as this would never be in the database
+    }
+
+    res = inbound.main_handler(InboundMessage(**inbound_payload))
 
     assert "you don't have permission" in res["response"]
     assert not res["http"][0]
     assert 200 <= res["http"][1] < 300
 
 
-def test_message_concat(mocker, default_inbound):
-    """If the message is too long."""
-    mocker.patch("inbound.texts.config.General.SANDBOX_MODE", True)
-    mocker.patch("inbound.usage.config.General.SANDBOX_MODE", True)
+# Removed after Twilio migration
+# def test_message_concat(mocker, default_inbound):
+#     """If the message is too long."""
+#     mocker.patch("inbound.texts.config.General.SANDBOX_MODE", True)
+#     mocker.patch("inbound.usage.config.General.SANDBOX_MODE", True)
 
-    res = inbound.main_handler(
-        {
-            **default_inbound,
-            "text": "test message that is too long and is split by the carrier",
-            "concat": "true",
-            "concat-part": "1"
-        }
-    )
+#     res = inbound.main_handler(
+#         {
+#             **default_inbound,
+#             "text": "test message that is too long and is split by the carrier",
+#             "concat": "true",
+#             "concat-part": "1"
+#         }
+#     )
 
-    assert "Your message was too long" in res["response"]
-    assert not res["http"][0]
-    assert 200 <= res["http"][1] < 300
+#     assert "Your message was too long" in res["response"]
+#     assert not res["http"][0]
+#     assert 200 <= res["http"][1] < 300
 
 
 def test_invalid_inbound(mocker, default_inbound):
     mocker.patch("inbound.texts.config.General.SANDBOX_MODE", True)
     mocker.patch("inbound.usage.config.General.SANDBOX_MODE", True)
 
-    res = inbound.main_handler(
-        {
-            **default_inbound,
-            "text": "hello",
-        }
-    )
+    inbound_payload = {
+        **default_inbound,
+        "body": "hello",
+    }
+
+    res = inbound.main_handler(InboundMessage(**inbound_payload))
 
     assert "invalid" in res["response"]
     assert not res["http"][0]
@@ -57,12 +59,12 @@ def test_invalid_app(mocker, default_inbound):
     mocker.patch("inbound.texts.config.General.SANDBOX_MODE", True)
     mocker.patch("inbound.usage.config.General.SANDBOX_MODE", True)
 
-    res = inbound.main_handler(
-        {
-            **default_inbound,
-            "text": "app: askjdcasldjc",
-        }
-    )
+    inbound_payload = {
+        **default_inbound,
+        "body": "app: askjdcasldjc",
+    }
+
+    res = inbound.main_handler(InboundMessage(**inbound_payload))
 
     assert "app does not exist" in res["response"]
     assert not res["http"][0]
@@ -73,13 +75,12 @@ def test_run_app(mocker, user_git_pytest):
     mocker.patch("inbound.texts.config.General.SANDBOX_MODE", True)
     mocker.patch("inbound.usage.config.General.SANDBOX_MODE", True)
 
-    res = inbound.main_handler(
-        {
-            "msisdn": user_git_pytest["Phone"],
-            "text": "app: apps",
-            "concat": False
-        }
-    )
+    inbound_payload = {
+        "phone_number": user_git_pytest["Phone"],
+        "body": "app: apps",
+    }
+
+    res = inbound.main_handler(InboundMessage(**inbound_payload))
 
     assert "available" in res["response"]
     assert not res["http"][0]
@@ -90,15 +91,14 @@ def test_app_error_handling(mocker, user_git_pytest):
     mocker.patch("inbound.texts.config.General.SANDBOX_MODE", True)
     mocker.patch("inbound.usage.config.General.SANDBOX_MODE", True)
 
-    res = inbound.main_handler(
-        {
-            "msisdn": user_git_pytest["Phone"],
-            "text": "app: wordhunt\n" \
-                "options: width = notnumber; height = notnumber\n" \
-                "hagsyausidmsnajs",
-            "concat": False
-        }
-    )
+    inbound_payload = {
+        "phone_number": user_git_pytest["Phone"],
+        "body": "app: wordhunt\n" \
+            "options: width = notnumber; height = notnumber\n" \
+            "hagsyausidmsnajs"
+    }
+
+    res = inbound.main_handler(InboundMessage(**inbound_payload))
 
     assert "Unfortunately" in res["response"]
     assert not res["http"][0]

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -11,8 +11,8 @@ import errors
 def test_raise_on_no_app_specified():
     """Make sure an `errors.InvalidInbound` is raised when no app is specified."""
     inbound = {
-        "msisdn": "00000000000",
-        "text": "noapphere"
+        "phone_number": "00000000000",
+        "body": "noapphere"
     }
 
     with pytest.raises(errors.InvalidInbound):

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -16,4 +16,4 @@ def test_raise_on_no_app_specified():
     }
 
     with pytest.raises(errors.InvalidInbound):
-        app = parsing.requested_app(inbound)
+        app = parsing.requested_app(parsing.InboundMessage(**inbound))

--- a/tests/test_twilio.py
+++ b/tests/test_twilio.py
@@ -2,7 +2,7 @@
 import texts
 
 
-def test_vonage_balance():
+def test_twilio_balance():
     """Make sure the Vonage account has at least $3 loaded."""
-    balance = float(texts.nexmo_client.get_balance()["value"])
-    assert balance > 1
+    balance = float(texts.twilio_client.balance.fetch().balance)
+    assert balance >= 3

--- a/texts.py
+++ b/texts.py
@@ -2,19 +2,17 @@
 Sending text messages back.
 """
 # External
-import nexmo
+from twilio.rest import Client as TwilioClient
 
 # Project
 import keys
 import config
 
 
-nexmo_client = nexmo.Client(
-    key = keys.Nexmo.API_KEY,
-    secret = keys.Nexmo.API_SECRET
+twilio_client = TwilioClient(
+    keys.Twilio.ACCOUNT_SID,
+    keys.Twilio.AUTH_TOKEN
 )
-
-sms = nexmo.Sms(nexmo_client)
 
 
 def send_message(content: str, recipient: str) -> bool:
@@ -26,13 +24,13 @@ def send_message(content: str, recipient: str) -> bool:
     if config.General.SANDBOX_MODE:
         return True
 
-    vonage_res = sms.send_message(
-        {
-            "type": "unicode",
-            "from": keys.Nexmo.SENDER,
-            "to": recipient,
-            "text": str(content)
-        }
+    message_sent = twilio_client.messages.create(
+        to = recipient,
+        from_ = keys.Twilio.SENDER,
+        body = content
     )
 
+    return True
+
+    # Create success check for Twilio
     return True if vonage_res["messages"][0]["status"] == "0" else False


### PR DESCRIPTION
Migrate to Twilio. Changes keys, the InboundMessage data model, all tests needing the new data model structure, and the way the inbound-sms accepts pings.