### PR TITLE
Zapier agent tools and tool authentication

### DIFF
--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -14,7 +14,7 @@ jobs:
 
       - name: Inject keys
         run: |
-          echo -en '${{ secrets.KEYS_INI }}' >> keys.ini
+          echo -en '${{ secrets.KEYS_YAML }}' >> keys.yaml
           echo -en '${{ secrets.CONFIG_INI }}' >> config.ini 
 
       - name: Authenticate GCP

--- a/.github/workflows/google-cloud.yml
+++ b/.github/workflows/google-cloud.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Inject keys and config
         run: |
-          echo -en '${{ secrets.KEYS_INI }}' >> keys.ini
+          echo -en '${{ secrets.KEYS_YAML }}' >> keys.yaml
           echo -en '${{ secrets.CONFIG_INI }}' >> config.ini
 
       - name: Authenticate GCP

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Inject keys and config
         run: |
-          echo -en '${{ secrets.KEYS_INI }}' >> keys.ini
+          echo -en '${{ secrets.KEYS_YAML }}' >> keys.yaml
           echo -en '${{ secrets.CONFIG_INI }}' >> config.ini
 
       - name: Run tests with pytest

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ wsl_venv/
 .vscode/
 
 keys.ini
+keys.yaml
 config.ini
 
 __pycache__/

--- a/apps/billsplit/billsplit_db.py
+++ b/apps/billsplit/billsplit_db.py
@@ -2,14 +2,13 @@
 import deta
 import requests
 
-import string
 import random
 
-import keys
+from keys import KEYS
 import texts
 
 
-deta_client = deta.Deta(keys.Deta.PROJECT_KEY)
+deta_client = deta.Deta(KEYS["Deta"]["project_key"])
 db = deta_client.Base("billsplit")
 
 

--- a/apps/gpt/__init__.py
+++ b/apps/gpt/__init__.py
@@ -2,6 +2,7 @@
 import utils
 
 from . import agency
+from . import tool_auth
 
 
 APP_HELP = "Get a GPT response."
@@ -10,7 +11,9 @@ APP_HELP = "Get a GPT response."
 @utils.app_handler(APP_HELP)
 def handler(content: str, options: dict[str, str]) -> str:
     """Handler for the GPT applet."""
-    response: str = agency.run_agent(content)
+    toolkit = tool_auth.build_tools(options["inbound_phone"])
+    agent_executor = agency.create_agent_executor(toolkit)
+    response: str = agency.run_agent(agent_executor, content)
 
     # Remove spaces and newlines from the start of the response
     return response.strip()

--- a/apps/gpt/completions.py
+++ b/apps/gpt/completions.py
@@ -1,11 +1,11 @@
 """Completion backend using the OpenAI SDK for the GPT applet."""
 import openai
 
-import keys
+from keys import KEYS
 
 
 # Authennticate OpenAI
-openai.api_key = keys.OpenAI.API_KEY
+openai.api_key = KEYS["OpenAI"]["api_key"]
 
 
 def gpt_response(prompt: str) -> str:

--- a/apps/gpt/retrieval.py
+++ b/apps/gpt/retrieval.py
@@ -11,11 +11,11 @@ import json
 
 from abc import ABC, abstractmethod
 
-import keys
+from keys import KEYS
 
 
-llm = ChatOpenAI(model_name="gpt-4", openai_api_key=keys.OpenAI.API_KEY, temperature=0)
-embeddings = OpenAIEmbeddings(openai_api_key=keys.OpenAI.API_KEY)
+llm = ChatOpenAI(model_name="gpt-4", openai_api_key=KEYS["OpenAI"]["api_key"], temperature=0)
+embeddings = OpenAIEmbeddings(openai_api_key=KEYS["OpenAI"]["api_key"])
 splitter = TokenTextSplitter(
     encoding_name="cl100k_base", 
     chunk_size=300, 

--- a/apps/gpt/tool_auth.py
+++ b/apps/gpt/tool_auth.py
@@ -1,0 +1,42 @@
+"""Load tools depending on authorization."""
+from langchain.agents import Tool
+from langchain.utilities import GoogleSerperAPIWrapper
+from langchain.utilities.zapier import ZapierNLAWrapper
+from langchain.agents.agent_toolkits import ZapierToolkit
+
+from keys import KEYS
+
+from . import retrieval
+
+
+JSON_STRING_INPUT_INSTRUCTIONS = "Input must be a JSON string with the keys \"source\" and \"query\"."
+
+no_auth_tools = [
+    Tool(
+        name="Google Search",
+        func=GoogleSerperAPIWrapper(serper_api_key=KEYS["GoogleSerper"]["api_key"]).run,
+        description="Useful for when you need to search Google."
+    ),
+    Tool(
+        name="Website Answerer",
+        func=retrieval.WebsiteAnswerer.answer_json_string,
+        description=(
+            "Useful for when you need to answer a question about the content on a website. "
+            f"{JSON_STRING_INPUT_INSTRUCTIONS} \"source\" is the URL of the website."
+        )
+    )
+]
+
+
+def build_tools(inbound_phone: str) -> list[Tool]:
+    """Build all authenticated tools given a phone number."""
+    added_tools = []
+
+    # Zapier
+    if inbound_phone in KEYS["ZapierNLA"]:
+        zapier_key = KEYS["ZapierNLA"][inbound_phone]
+        zapier_wrapper = ZapierNLAWrapper(zapier_nla_api_key=zapier_key)
+        zapier_toolkit = ZapierToolkit.from_zapier_nla_wrapper(zapier_wrapper)
+        added_tools.extend(zapier_toolkit.get_tools())
+
+    return no_auth_tools + added_tools

--- a/apps/jokes/__init__.py
+++ b/apps/jokes/__init__.py
@@ -1,7 +1,7 @@
 import requests
 
 import utils
-import keys
+from keys import KEYS
 
 
 APP_HELP = "Get a random joke."
@@ -16,7 +16,7 @@ def random_joke(tags: str):
         endpoint,
         params = {
             "include-tags": tags,
-            "api-key": keys.HumorAPI.API_KEY
+            "api-key": KEYS["HumorAPI"]["api_key"]
         }
     )
 

--- a/apps/weather/data.py
+++ b/apps/weather/data.py
@@ -6,7 +6,7 @@ import requests
 import datetime as dt
 
 # Project
-import keys
+from keys import KEYS
 
 
 WEATHER_ENDPOINT = "https://api.openweathermap.org/data/2.5/weather"
@@ -45,7 +45,7 @@ def current_weather(
         WEATHER_ENDPOINT, 
         {
             "q": ",".join([ele for ele in [city.lower(), state.lower(), country.lower()] if ele]), 
-            "appid": keys.OpenWeatherMap.API_KEY
+            "appid": KEYS["OpenWeatherMap"]["api_key"]
         }
     )
 

--- a/keys.py
+++ b/keys.py
@@ -1,71 +1,14 @@
 """
-Read keys.ini and parse. Supply keys.ini in the following format.
-
-
-[Twilio]
-account_sid = 
-auth_token = 
-sender = 
-my_number = 
-
-
-[Deta]
-...
+Read keys.yaml.
 """
 import os
-import configparser
+import yaml
 
 
-keys = configparser.RawConfigParser()
-keys.read(
-    os.path.join(
-        (current_dir := os.path.realpath(os.path.dirname(__file__))),
-        "keys.ini"
-    )
+keys_path = os.path.join(
+    (current_dir := os.path.realpath(os.path.dirname(__file__))),
+    "keys.yaml"
 )
 
-
-def environment_or_internal(env: str, provider: str) -> str:
-    """
-    Checks for a key in the environment, and if it's not there, looks inside a 
-    keys.ini file. Assumes the key in keys.ini is stored as `api_key`. A `KeyError`
-    will be raised if the key cannot be found in either environment or keys.ini.
-
-    This method is necessary as opposed to using `os.environ.get` because if a key is
-    in the environment and not in keys.ini, we don't want to check keys.ini for a default
-    value and raise a `KeyError`.
-    """
-    try:
-        return os.environ[env]
-    except KeyError:  # not in the environment, check keys.ini
-        return keys[provider]["api_key"]  # raise KeyError if not found
-
-
-class Twilio:
-    """Sending text messages."""
-    _twilio_keys = keys["Twilio"]
-
-    ACCOUNT_SID = _twilio_keys["account_sid"]
-    AUTH_TOKEN = _twilio_keys["auth_token"]
-    SENDER = _twilio_keys["sender"]
-    MY_NUMBER = _twilio_keys["my_number"]
-
-
-class Deta:
-    PROJECT_KEY = keys["Deta"]["project_key"]
-
-
-class HumorAPI:
-    API_KEY = keys["Humor API"]["api_key"]
-
-
-class OpenWeatherMap:
-    API_KEY = keys["OpenWeatherMap"]["api_key"]
-
-
-class OpenAI:
-    API_KEY = environment_or_internal("OPENAI_API_KEY", "OpenAI")
-
-
-class GoogleSerper:
-    API_KEY = environment_or_internal("SERPER_API_KEY", "Google Serper")
+with open(keys_path, "r") as f:
+    KEYS = yaml.safe_load(f)

--- a/permissions.py
+++ b/permissions.py
@@ -5,10 +5,10 @@ Read permissions stored in a Deta Base.
 import deta
 
 # Project
-import keys
+from keys import KEYS
 
 
-deta_client = deta.Deta(keys.Deta.PROJECT_KEY)
+deta_client = deta.Deta(KEYS["Deta"]["project_key"])
 permissions_db = deta_client.Base("permissions")
 
 
@@ -23,7 +23,7 @@ def db_init() -> str:
     db_res: dict = permissions_db.put(
         {
             "Name": "Prerit Das",
-            "Phone": keys.Twilio.MY_NUMBER,
+            "Phone": KEYS["Twilio"]["my_number"],
             "Permissions": "all"
         }
     )

--- a/tests/badge.svg
+++ b/tests/badge.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">96%</text>
-        <text x="80" y="14">96%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">95%</text>
+        <text x="80" y="14">95%</text>
     </g>
 </svg>

--- a/tests/test_app_invite.py
+++ b/tests/test_app_invite.py
@@ -8,7 +8,7 @@ from twilio.rest import Client  # mock an invalid client
 from twilio.base.exceptions import TwilioRestException
 
 from apps import invite
-import keys
+from keys import KEYS
 
 
 def test_handler():
@@ -49,7 +49,7 @@ def test_inviting(mocker, default_options):
 
 def test_failed_delivery(mocker, default_options):
     """Mock a bad API key."""
-    mocker.patch("texts.twilio_client", Client(keys.Twilio.ACCOUNT_SID, "invalid"))
+    mocker.patch("texts.twilio_client", Client(KEYS["Twilio"]["account_sid"], "invalid"))
 
     with pytest.raises(TwilioRestException):
         invite.handler("14259023246", default_options)

--- a/texts.py
+++ b/texts.py
@@ -5,13 +5,13 @@ Sending text messages back.
 from twilio.rest import Client as TwilioClient
 
 # Project
-import keys
+from keys import KEYS
 import config
 
 
 twilio_client = TwilioClient(
-    keys.Twilio.ACCOUNT_SID,
-    keys.Twilio.AUTH_TOKEN
+    KEYS["Twilio"]["account_sid"],
+    KEYS["Twilio"]["auth_token"]
 )
 
 
@@ -26,7 +26,7 @@ def send_message(content: str, recipient: str) -> bool:
 
     message_sent = twilio_client.messages.create(
         to = recipient,
-        from_ = keys.Twilio.SENDER,
+        from_ = KEYS["Twilio"]["sender"],
         body = content
     )
 

--- a/usage.py
+++ b/usage.py
@@ -8,11 +8,11 @@ import string
 import random
 
 # Project
-import keys
+from keys import KEYS
 import config
 
 
-deta = deta.Deta(keys.Deta.PROJECT_KEY)
+deta = deta.Deta(KEYS["Deta"]["project_key"])
 usage_db = deta.Base("usage")
 permissions_db = deta.Base("permissions")
 


### PR DESCRIPTION
Switch to YAML for providing keys, not INI. This allows us to check if keys for an inbound phone for any tool are provided. If they are, we add those tools to the toolkit before passing those to an agent. 

Zapier NLA API support added. Automatically adds the tools "exposed" for an account. Because I am the only one with access to the GPT app, currently it's just me. For someone else to use it, their API key for Zapier NLA would have to be entered into keys.yaml under ZapierNLA.

```yaml
ZapierNLA:
    10001112233: agsdcashdcasdhjcbasjldhcb
```

This will automatically build the Zapier tools and empower the agent with those tools when receiving a text from 10001112233.