### PR TITLE
Query URLs returned by search

### DIFF
--- a/tests/badge.svg
+++ b/tests/badge.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">94%</text>
-        <text x="80" y="14">94%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">93%</text>
+        <text x="80" y="14">93%</text>
     </g>
 </svg>


### PR DESCRIPTION
Creates a new `GoogleSerperAPIWrapperURL` class that inherits from the original wrapper but redefines the parser function. Redefining it to include a URL for each snippet, so that the agent can use the WebsiteAnswerer tool to ask questions to those returned articles/webpages. 